### PR TITLE
Unregister and Unsubscribe when client disconnects

### DIFF
--- a/lib/realm.js
+++ b/lib/realm.js
@@ -51,6 +51,17 @@ Realm.prototype.addSession = function(session) {
     }
 };
 
+Realm.prototype.cleanup = function(session) {
+    var self = this;
+    _.forEach(this.procedures, function(procedure) {
+        self.unregister(procedure.id, session);
+    });
+    _.forEach(this.topics, function(topic) {
+        topic.removeSession(session);
+    });
+    return this;
+};
+
 Realm.prototype.removeSession = function(session) {
     var self = this;
 

--- a/lib/realm.js
+++ b/lib/realm.js
@@ -52,13 +52,18 @@ Realm.prototype.addSession = function(session) {
 };
 
 Realm.prototype.cleanup = function(session) {
-    var self = this;
+
     _.forEach(this.procedures, function(procedure) {
-        self.unregister(procedure.id, session);
-    });
-    _.forEach(this.topics, function(topic) {
+        this.unregister(procedure.id, session);
+    }, this);
+
+    _.forEach(this.topics, function(topic, key, topics) {
         topic.removeSession(session);
+        if (topic.sessions.length === 0) {
+            delete topics[key];
+        }
     });
+
     return this;
 };
 
@@ -93,14 +98,26 @@ Realm.prototype.subscribe = function(uri, session) {
 };
 
 Realm.prototype.unsubscribe = function(id, session) {
-    var self = this;
 
-    if (_.isNumber(id) && self.session(session)) {
-        _.find(self.topics, function (t) {
-            return t.id === id;
-        })
-        .removeSession(session);
-    } else {
+    if (_.isNumber(id) && this.session(session)) {
+
+        var key,
+            topic = _.find(this.topics, function(t, k) {
+                if (t.id === id) {
+                    key = k;
+                    return true;
+                }
+            });
+
+        if (topic) {
+            topic.removeSession(session);
+            if (topic.sessions.length === 0) {
+                delete this.topics[key];
+            }
+        }
+        else {
+            throw new TypeError('wamp.error.no_such_topic');
+        }
     }
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -67,8 +67,8 @@ function Router(opts) {
 
         session.on('close', function (defer) {
             try {
-                logger.debug('removing session from realm', session.realm);
-                self.realm(session.realm).removeSession(session);
+                logger.debug('removing & cleaning session from realm', session.realm);
+                self.realm(session.realm).cleanup(session).removeSession(session);
                 defer.resolve();
             } catch (err) {
                 defer.reject(err);


### PR DESCRIPTION
Hello, 
Following to this issue : https://github.com/christian-raedel/nightlife-rabbit/issues/5 
We add a new realm method :  
**_cleanup**_ which its called when a client is disconnected (on socket close) 

This method : 
- unregisters all the procedures attached by the session on the realm
- removes the onclose session from the topic.sessions  array  
  - if the session was the last one : the topic is deleted from the realm topics object

The method Realm.prototype.unsubscribe has been updated : 
when unsubscribe is called, if the topic.session gets empty it is deleted. 
(to avoid a growing up unused topics object ) 

Regards,
François 
